### PR TITLE
Properly insert AsciiDoc title markers

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -257,12 +257,12 @@ BEGIN {
     my $UnicodeGCString_available = 0;
     $UnicodeGCString_available = 1 if (eval { require Unicode::GCString });
     eval {
-        sub columns($$$) {
+        sub chars($$$) {
             my $text = shift;
             my $encoder = shift;
             $text = $encoder->decode($text) if (defined($encoder) && $encoder->name ne "ascii");
             if ($UnicodeGCString_available) {
-                return Unicode::GCString->new($text)->columns();
+                return Unicode::GCString->new($text)->chars();
             } else {
                 $text =~ s/\n$//s;
                 return length($text) if !(defined($encoder) && $encoder->name ne "ascii");
@@ -318,7 +318,9 @@ sub parse {
                  ($line =~ m/^(={2,}|-{2,}|~{2,}|\^{2,}|\+{2,})$/) and
                  (defined($paragraph) )and
                  ($paragraph =~ m/^[^\n]*\n$/s) and
-                 (columns($paragraph, $self->{TT}{po_in}{encoder}, $ref) == (length($line)))) {
+                 # subtract one because chars includes the newline on the paragraph
+                 ((chars($paragraph, $self->{TT}{po_in}{encoder}, $ref) - 1) == (length($line)))) {
+
             # Found title
             $wrapped_mode = 0;
             my $level = $line;
@@ -333,7 +335,7 @@ sub parse {
             $paragraph="";
             @comments=();
             $wrapped_mode = 1;
-            $self->pushline(($level x (columns($t, $self->{TT}{po_in}{encoder}, $ref)))."\n");
+            $self->pushline(($level x (chars($t, $self->{TT}{po_in}{encoder}, $ref)))."\n");
         } elsif ($line =~ m/^(={1,5})( +)(.*?)( +\1)?$/) {
             my $titlelevel1 = $1;
             my $titlespaces = $2;

--- a/t/data-30/TitlesUTF8.asciidoc
+++ b/t/data-30/TitlesUTF8.asciidoc
@@ -1,24 +1,24 @@
 Où mettre un titre ?
 ====================
 
-Titre 1
--------
+タイトル1
+-----
 
 Titre de niveau 2
 ~~~~~~~~~~~~~~~~~
 
-Titre de niveau 3
-^^^^^^^^^^^^^^^^^
+タイトルレベル3
+^^^^^^^^
 
 Titre de niveau 4
 +++++++++++++++++
 
 = Titre du document (niveau 0) =
 
-== Titre de section (niveau 1) ==
+== セクションタイトル（レベル1） ==
 
 === Titre de section (niveau 2) ===
 
-==== Titre de section (niveau 3) ====
+==== セクションタイトル（レベル3） ====
 
 ===== Titre de section (niveau 4) =====

--- a/t/data-30/TitlesUTF8.po
+++ b/t/data-30/TitlesUTF8.po
@@ -1,6 +1,8 @@
 # SOME DESCRIPTIVE TITLE
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
+# Japanese translations are from translate.google.com.
+# They are intended to test double-width unicode characters
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
@@ -26,7 +28,7 @@ msgstr "Où mettre un titre ?"
 #: ../data-30/Titles.asciidoc:5
 #, fuzzy, no-wrap
 msgid "Title1"
-msgstr "Titre 1"
+msgstr "タイトル1"
 
 #. type: Title ~
 #: ../data-30/Titles.asciidoc:8
@@ -38,7 +40,7 @@ msgstr "Titre de niveau 2"
 #: ../data-30/Titles.asciidoc:11
 #, fuzzy, no-wrap
 msgid "Title level 3"
-msgstr "Titre de niveau 3"
+msgstr "タイトルレベル3"
 
 #. type: Title +
 #: ../data-30/Titles.asciidoc:14
@@ -56,7 +58,7 @@ msgstr "Titre du document (niveau 0)"
 #: ../data-30/Titles.asciidoc:18
 #, fuzzy, no-wrap
 msgid "Section title (level 1)"
-msgstr "Titre de section (niveau 1)"
+msgstr "セクションタイトル（レベル1）"
 
 #. type: Title ===
 #: ../data-30/Titles.asciidoc:20
@@ -68,7 +70,7 @@ msgstr "Titre de section (niveau 2)"
 #: ../data-30/Titles.asciidoc:22
 #, fuzzy, no-wrap
 msgid "Section title (level 3)"
-msgstr "Titre de section (niveau 3)"
+msgstr "セクションタイトル（レベル3）"
 
 #. type: Title =====
 #: ../data-30/Titles.asciidoc:24


### PR DESCRIPTION
Asciidoctor requires that title markers be the same character
length as the title.  The original code counted length in ASCII
characters, without regard to Unicode.  Therefore double-character
languages got too many markers.  This patch uses the chars method
instead of the columns method